### PR TITLE
now fix linux build...

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@emotion/react": "^11.13.3",
         "@emotion/styled": "^11.13.0",
         "@mui/material": "^6.1.5",
+        "@rollup/rollup-darwin-x64": "*",
         "jszip": "^3.10.1",
         "pankosmia-rcl": "0.1.46",
         "pithekos-lib": "^0.11.4",
@@ -21,11 +22,14 @@
       },
       "devDependencies": {
         "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
-        "@rollup/rollup-win32-x64-msvc": "^4.60.3",
         "@vitejs/plugin-react": "^4.3.4",
         "husky": "^9.1.7",
         "prettier": "3.8.1",
         "vite": "^6.0.7"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-darwin-x64": "^4.60.3",
+        "@rollup/rollup-win32-x64-msvc": "^4.60.3"
       },
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0",
@@ -3503,13 +3507,12 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
-      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.3.tgz",
+      "integrity": "sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3803,8 +3806,8 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "os": [
         "win32"
       ]
@@ -15316,6 +15319,20 @@
         "@rollup/rollup-win32-x64-msvc": "4.60.1",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
     },
     "node_modules/rollup/node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.60.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   },
   "devDependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
-    "@rollup/rollup-win32-x64-msvc": "^4.60.3",
     "@vitejs/plugin-react": "^4.3.4",
     "husky": "^9.1.7",
     "prettier": "3.8.1",
@@ -50,5 +49,9 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "optionalDependencies": {
+    "@rollup/rollup-darwin-x64": "^4.60.3",
+    "@rollup/rollup-win32-x64-msvc": "^4.60.3"
   }
 }


### PR DESCRIPTION
This PR is:

1. `npm uninstall @rollup/rollup-win32-x64-msvc`
2. `npm install @rollup/rollup-win32-x64-msvc --save-optional`
3. `npm install @rollup/rollup-darwin-x64 --save-optional`

to fix this:
```
npm error code EBADPLATFORM
npm error notsup Unsupported platform for @rollup/rollup-win32-x64-msvc@4.60.3: wanted {"os":"win32","cpu":"x64"} (current: {"os":"linux","cpu":"x64"})
```