### PR TITLE
Remove hardcoded domain and port

### DIFF
--- a/src/pages/CreateTCProject.jsx
+++ b/src/pages/CreateTCProject.jsx
@@ -69,7 +69,7 @@ export default function CreatTCProject() {
     }
 
     try {
-      const response = await fetch("http://127.0.0.1:19119/temp/bytes", {
+      const response = await fetch("/temp/bytes", {
         method: "POST",
         body: formData,
       });


### PR DESCRIPTION
This PR removes a fully-qualified URL that created problems when running two instances of Pankosmia:
- the second instance will not use port 19119
- a different domain (eg localhost vs 127.0.0.1) will trigger a CORS error

The solution is to remove this information from all URLs and instead let the browser derive this information from the page context.